### PR TITLE
Add a gitignore for jekyll-generated stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/_site
+.DS_Store


### PR DESCRIPTION
Ignores `_site` and `.DS_Store`.
