### PR TITLE
Updating licensing text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Thanks for contributing! There are two ways to submit changes:
 5. Submit a pull request to open a discussion about your proposed changes.
 6. We'll review your pull request and merge it if your changes are acceptable. Otherwise, we'll request additional changes from you.
 
----
+### Public domain
 
 The project is in the public domain within the United States, and
 copyright and related rights in the work worldwide are waived through

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,7 +15,7 @@ the public domain by waiving all of his or her rights to the work worldwide
 under copyright law, including all related and neighboring rights, to the
 extent allowed by law.
 
-You can copy, modify, distribute and perform the work, even for commercial 
+You can copy, modify, distribute and perform the work, even for commercial
 purposes, all without asking permission. See Other Information below.
 
 ### Other Information

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ Run the Jekyll server and watch for file changes:
 Your computer should now be serving your local copy of the site at:
 
 [http://0.0.0.0:4000](http://0.0.0.0:4000).
+


### PR DESCRIPTION
Minor tweaks to language, basically just renames `TERMS` to `LICENSE` (which is the more common standard).
